### PR TITLE
Python3.3+ requires byte array instead of str.

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -308,6 +308,8 @@ class GraphAPI(object):
                 args["access_token"] = self.access_token
         post_data = None if post_args is None else urlencode(post_args)
         try:
+            if sys.hexversion >= 0x03030000:
+                post_data = post_data.encode('utf8')
             file = urlopen("https://graph.facebook.com/" + path + "?" +
                            urlencode(args),
                            post_data, timeout=self.timeout)

--- a/facebook.py
+++ b/facebook.py
@@ -36,6 +36,7 @@ if user:
 import time
 import hashlib
 import hmac
+import sys
 import base64
 import logging
 import socket


### PR DESCRIPTION
In python 3.3+ urllib.request() require POST data as a byte array rather than string.

Docs:
http://docs.python.org/dev/library/urllib.request.html

Fix:
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
